### PR TITLE
修复不再使用的MutationObserver引起的内存泄漏问题

### DIFF
--- a/packages/browser-vm/src/modules/mutationObserver.ts
+++ b/packages/browser-vm/src/modules/mutationObserver.ts
@@ -4,9 +4,14 @@ export function observerModule(_sandbox: Sandbox) {
   const observerSet = new Set<MutationObserver>();
 
   class ProxyMutationObserver extends MutationObserver {
-    constructor(cb: MutationCallback) {
-      super(cb);
+    observe(target: Node, options?: MutationObserverInit | undefined): void {
       observerSet.add(this);
+      return super.observe(target, options);
+    }
+
+    disconnect(): void {
+      observerSet.delete(this);
+      return super.disconnect();
     }
   }
 


### PR DESCRIPTION
## Description
MutationObserver当前会被劫持，每个MutationObserver实例都会被缓存到observerSet中

改成：observe的时候缓存到observerSet，disconnect的时候删除实例

## Related Issue
暂无

## Motivation and Context
MutationObserver实例较多的时候，对于长时间使用的Web应用来说，内存会不断上涨，最终导致浏览器崩溃

## How Has This Been Tested
打了js heap验证，在我们的项目目前是可以正常运行的

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
