### PR TITLE
fix(preload): preload api shouldn't invoke if loaded

### DIFF
--- a/packages/core/src/plugins/preload.ts
+++ b/packages/core/src/plugins/preload.ts
@@ -205,6 +205,11 @@ declare module '@garfish/core' {
 export function GarfishPreloadPlugin() {
   return function (Garfish: interfaces.Garfish): interfaces.Plugin {
     Garfish.preloadApp = (appName) => {
+      if (loadedMap[appName]) {
+        return;
+      }
+
+      loadedMap[appName] = true;
       loadAppResource(Garfish.loader, Garfish.appInfos[appName], true);
     };
 


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
preload这个api用户可以在任何时间调用。
但是目前没有判断这个这个是否被preload插件自动获取了，或者用户调用了preload后，也没有写入loadedMap。
所以我觉得这块可以加这方面的逻辑。

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
减少多余的函数执行。

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
