### PR TITLE
fix: styled-components / insertRule

### DIFF
--- a/packages/browser-vm/__tests__/__snapshots__/dynamic-style.spec.ts.snap
+++ b/packages/browser-vm/__tests__/__snapshots__/dynamic-style.spec.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sandbox: dynamic style append text node 1`] = `
+Array [
+  ".app .a { color: black; }.app .b { color: white; }",
+  Array [
+    ".app .a {color: black;}",
+    ".app .b {color: white;}",
+  ],
+]
+`;
+
+exports[`Sandbox: dynamic style insertRule 1`] = `
+Array [
+  ".app .a {color: black;}",
+  ".app .b {color: white;}",
+  ".app .c {color: white;}",
+]
+`;
+
+exports[`Sandbox: dynamic style set textContent 1`] = `
+Array [
+  ".app .a { color: black; }",
+  Array [
+    ".app .a {color: black;}",
+  ],
+]
+`;

--- a/packages/browser-vm/__tests__/dom-side-effect.spec.ts
+++ b/packages/browser-vm/__tests__/dom-side-effect.spec.ts
@@ -1,10 +1,6 @@
 import { Sandbox } from '../src/sandbox';
 import assert from 'assert';
 import { sandboxMap } from '../src/utils';
-import {
-  recordStyledComponentCSSRules,
-  rebuildCSSRules,
-} from '../src/dynamicNode';
 
 // Garfish 使用 Proxy 对 dom 进行了劫持, 同时对调用 dom 的函数做了劫持, 修正 dom 节点的类型
 // 对调用 dom 的相关方法进行测试

--- a/packages/browser-vm/__tests__/dom.spec.ts
+++ b/packages/browser-vm/__tests__/dom.spec.ts
@@ -1,9 +1,5 @@
 import { Sandbox } from '../src/sandbox';
 import { sandboxMap } from '../src/utils';
-import {
-  recordStyledComponentCSSRules,
-  rebuildCSSRules,
-} from '../src/dynamicNode';
 
 // Garfish 使用 Proxy 对 dom 进行了劫持, 同时对调用 dom 的函数做了劫持, 修正 dom 节点的类型
 // 对调用 dom 的相关方法进行测试

--- a/packages/browser-vm/__tests__/dom.spec.ts
+++ b/packages/browser-vm/__tests__/dom.spec.ts
@@ -160,49 +160,4 @@ describe('Sandbox:Dom & Bom', () => {
       { next },
     );
   });
-
-  const createStyleComponentElementWithRecord = () => {
-    const styleComponentElement = document.createElement('style');
-    document.head.appendChild(styleComponentElement);
-    const cssRuleExample1 = '.test1 { color: red }';
-    const cssRuleExample2 = '.test2 { color: red }';
-    styleComponentElement.sheet?.insertRule(`${cssRuleExample1}`);
-    styleComponentElement.sheet?.insertRule(`${cssRuleExample2}`);
-    sandbox.dynamicStyleSheetElementSet.add(styleComponentElement);
-
-    recordStyledComponentCSSRules(
-      sandbox.dynamicStyleSheetElementSet,
-      sandbox.styledComponentCSSRulesMap,
-    );
-    return styleComponentElement;
-  };
-
-  it('should record the css rules of styled-components correctly', () => {
-    const styleComponentElement = createStyleComponentElementWithRecord();
-    const cssRules = sandbox.styledComponentCSSRulesMap.get(
-      styleComponentElement,
-    );
-    expect(cssRules?.length).toEqual(2);
-    expect((cssRules?.[0] as CSSStyleRule).selectorText).toEqual('.test2');
-    expect((cssRules?.[1] as CSSStyleRule).selectorText).toEqual('.test1');
-  });
-
-  it('should rebuild the css rules of styled-components in the correct order', () => {
-    const styleComponentElement = createStyleComponentElementWithRecord();
-
-    Object.defineProperty(window.HTMLStyleElement.prototype, 'sheet', {
-      writable: true,
-      value: {},
-    });
-    // @ts-ignore
-    styleComponentElement.sheet = new CSSStyleSheet();
-    rebuildCSSRules(
-      sandbox.dynamicStyleSheetElementSet,
-      sandbox.styledComponentCSSRulesMap,
-    );
-    const cssRules = styleComponentElement.sheet.cssRules;
-    expect(cssRules.length).toEqual(2);
-    expect((cssRules?.[0] as CSSStyleRule).selectorText).toEqual('.test2');
-    expect((cssRules?.[1] as CSSStyleRule).selectorText).toEqual('.test1');
-  });
 });

--- a/packages/browser-vm/__tests__/dynamic-style.spec.ts
+++ b/packages/browser-vm/__tests__/dynamic-style.spec.ts
@@ -123,18 +123,37 @@ describe('Sandbox: dynamic style', () => {
   it('should rebuild the css rules of styled-components in the correct order', () => {
     const styleComponentElement = createStyleComponentElementWithRecord();
 
-    Object.defineProperty(styleComponentElement, 'sheet', {
-      writable: true,
-      value: new CSSStyleSheet(),
-    });
-    const cssRules = styleComponentElement.sheet!.cssRules;
-    expect(cssRules.length).toEqual(0);
+    const parent = styleComponentElement.parentElement;
+    styleComponentElement.remove();
+    parent!.appendChild(styleComponentElement);
+
     rebuildCSSRules(
       sandbox.dynamicStyleSheetElementSet,
       sandbox.styledComponentCSSRulesMap,
     );
+    const cssRules = styleComponentElement.sheet!.cssRules;
     expect(cssRules.length).toEqual(2);
     expect((cssRules![0] as CSSStyleRule).selectorText).toEqual('.app .test2');
     expect((cssRules![1] as CSSStyleRule).selectorText).toEqual('.app .test1');
+  });
+
+  it('should be able to insertRule on old sheet after remount', () => {
+    const styleComponentElement = createStyleComponentElementWithRecord();
+    const oldSheet = styleComponentElement.sheet;
+
+    const parent = styleComponentElement.parentElement;
+    styleComponentElement.remove();
+    parent!.appendChild(styleComponentElement);
+
+    rebuildCSSRules(
+      sandbox.dynamicStyleSheetElementSet,
+      sandbox.styledComponentCSSRulesMap,
+    );
+    const cssRules = styleComponentElement.sheet!.cssRules;
+    expect(cssRules.length).toEqual(2);
+    expect((cssRules![0] as CSSStyleRule).selectorText).toEqual('.app .test2');
+    expect((cssRules![1] as CSSStyleRule).selectorText).toEqual('.app .test1');
+    oldSheet!.insertRule('.test3 {}', 2);
+    expect((cssRules![2] as CSSStyleRule).selectorText).toEqual('.app .test3');
   });
 });

--- a/packages/browser-vm/__tests__/dynamic-style.spec.ts
+++ b/packages/browser-vm/__tests__/dynamic-style.spec.ts
@@ -110,12 +110,14 @@ describe('Sandbox: dynamic style', () => {
 
   it('should record the css rules of styled-components correctly', () => {
     const styleComponentElement = createStyleComponentElementWithRecord();
-    const cssRules = sandbox.styledComponentCSSRulesMap.get(
-      styleComponentElement,
+    const data = sandbox.styledComponentCSSRulesMap.get(styleComponentElement);
+    expect(data!.cssRuleList!.length).toEqual(2);
+    expect((data!.cssRuleList![0] as CSSStyleRule).selectorText).toEqual(
+      '.app .test2',
     );
-    expect(cssRules!.length).toEqual(2);
-    expect((cssRules![0] as CSSStyleRule).selectorText).toEqual('.app .test2');
-    expect((cssRules![1] as CSSStyleRule).selectorText).toEqual('.app .test1');
+    expect((data!.cssRuleList![1] as CSSStyleRule).selectorText).toEqual(
+      '.app .test1',
+    );
   });
 
   it('should rebuild the css rules of styled-components in the correct order', () => {

--- a/packages/browser-vm/__tests__/dynamic-style.spec.ts
+++ b/packages/browser-vm/__tests__/dynamic-style.spec.ts
@@ -1,0 +1,91 @@
+import { __MockHead__ } from '@garfish/utils';
+import { Sandbox } from '../src/sandbox';
+import { StyleManager } from '@garfish/loader';
+
+describe('Sandbox: dynamic style', () => {
+  let sandbox: Sandbox;
+
+  const go = (code: string | (() => void)) => {
+    if (typeof code === 'function') {
+      code = `(${code})();`;
+    }
+    return `
+      const sandbox = __debug_sandbox__;
+      const Sandbox = sandbox.constructor;
+      const nativeWindow = Sandbox.getNativeWindow();
+      ${code}
+    `;
+  };
+
+  // Mock style transformer
+  const styleManagerProto = StyleManager.prototype;
+  const originalTransformCode = styleManagerProto.transformCode;
+  styleManagerProto.transformCode = function (code) {
+    return originalTransformCode('.app ' + code);
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = `<div id="root">123<div ${__MockHead__}></div></div>`;
+    sandbox = new Sandbox({
+      namespace: 'app',
+      el: () => document.querySelector('#root'),
+      baseUrl: 'http://test.app',
+      modules: [
+        () => ({
+          recover() {},
+          override: { go, jest, expect },
+        }),
+      ],
+    });
+  });
+
+  it('set textContent', (done) => {
+    sandbox.execScript(
+      go(() => {
+        const style = document.createElement('style');
+        style.textContent = '.a { color: black; }';
+        document.head.appendChild(style);
+        expect([
+          style.textContent,
+          Array.from(style.sheet!.cssRules).map((x) => x.cssText),
+        ]).toMatchSnapshot();
+        done();
+      }),
+      { done },
+    );
+  });
+
+  it('append text node', (done) => {
+    sandbox.execScript(
+      go(() => {
+        const style = document.createElement('style');
+        style.textContent = '.a { color: black; }';
+        document.head.appendChild(style);
+        style.appendChild(document.createTextNode('.b { color: white; }'));
+        expect([
+          style.textContent,
+          Array.from(style.sheet!.cssRules).map((x) => x.cssText),
+        ]).toMatchSnapshot();
+        done();
+      }),
+      { done },
+    );
+  });
+
+  it('insertRule', (done) => {
+    sandbox.execScript(
+      go(() => {
+        const style = document.createElement('style');
+        document.head.appendChild(style);
+        style.sheet!.insertRule('.b { color: white; }');
+        style.sheet!.insertRule('.a { color: black; }');
+        style.sheet!.insertRule('.c { color: white; }', 2);
+        expect(
+          Array.from(style.sheet!.cssRules).map((x) => x.cssText),
+        ).toMatchSnapshot();
+        done();
+      }),
+      { done },
+    );
+  });
+});

--- a/packages/browser-vm/__tests__/dynamic-style.spec.ts
+++ b/packages/browser-vm/__tests__/dynamic-style.spec.ts
@@ -111,13 +111,9 @@ describe('Sandbox: dynamic style', () => {
   it('should record the css rules of styled-components correctly', () => {
     const styleComponentElement = createStyleComponentElementWithRecord();
     const data = sandbox.styledComponentCSSRulesMap.get(styleComponentElement);
-    expect(data!.cssRuleList!.length).toEqual(2);
-    expect((data!.cssRuleList![0] as CSSStyleRule).selectorText).toEqual(
-      '.app .test2',
-    );
-    expect((data!.cssRuleList![1] as CSSStyleRule).selectorText).toEqual(
-      '.app .test1',
-    );
+    expect(data!.length).toEqual(2);
+    expect(data![0].split(' {')[0]).toEqual('.app .test2');
+    expect(data![1].split(' {')[0]).toEqual('.app .test1');
   });
 
   it('should rebuild the css rules of styled-components in the correct order', () => {

--- a/packages/browser-vm/src/dynamicNode/index.ts
+++ b/packages/browser-vm/src/dynamicNode/index.ts
@@ -153,13 +153,17 @@ export function rebuildCSSRules(
   dynamicStyleSheetElementSet.forEach((styleElement) => {
     const cssRules = styledComponentCSSRulesMap.get(styleElement);
     if (cssRules && (isStyledComponentsLike(styleElement) || cssRules.length)) {
-      for (let i = 0; i < cssRules.length; i++) {
-        const cssRule = cssRules[i];
-        // re-insert rules for styled-components element
-        styleElement.sheet?.insertRule(
-          cssRule.cssText,
-          styleElement.sheet?.cssRules.length,
-        );
+      if (styleElement.sheet) {
+        for (let i = 0; i < cssRules.length; i++) {
+          const cssRule = cssRules[i];
+          // re-insert rules for styled-components element
+          // call on prototype to skip transforming in insertRule
+          CSSStyleSheet.prototype.insertRule.call(
+            styleElement.sheet,
+            cssRule.cssText,
+            styleElement.sheet.cssRules.length,
+          );
+        }
       }
     }
   });

--- a/packages/browser-vm/src/dynamicNode/index.ts
+++ b/packages/browser-vm/src/dynamicNode/index.ts
@@ -143,35 +143,20 @@ export function rebuildCSSRules(
   >,
 ) {
   dynamicStyleSheetElementSet.forEach((styleElement) => {
-    const data = styledComponentCSSRulesMap.get(styleElement);
-    // cssRuleList will be overwritten when we access the new sheet, backup here
-    const { cssRuleList, addingRules } = data ?? {};
+    const rules = styledComponentCSSRulesMap.get(styleElement);
 
-    if (data && (isStyledComponentsLike(styleElement) || cssRuleList?.length)) {
+    if (rules && (isStyledComponentsLike(styleElement) || rules.length)) {
       const realSheet = Reflect.get(
         HTMLStyleElement.prototype,
         'sheet',
         styleElement,
       );
       if (realSheet) {
-        for (let i = 0; i < cssRuleList!.length; i++) {
-          const cssRule = cssRuleList![i];
+        for (let i = 0; i < rules.length; i++) {
+          const cssRule = rules[i];
           // re-insert rules for styled-components element
           // use realSheet to skip transforming
-          realSheet.insertRule(cssRule.cssText, realSheet.cssRules.length);
-        }
-        if (addingRules) {
-          for (const rule of addingRules) {
-            // rules added when the app was hidden in cache mode.
-            // with transforming
-            styleElement.sheet!.insertRule(
-              rule,
-              styleElement.sheet!.cssRules.length,
-            );
-          }
-          while (addingRules.length) {
-            addingRules.pop();
-          }
+          realSheet.insertRule(cssRule, i);
         }
       }
     }

--- a/packages/browser-vm/src/dynamicNode/index.ts
+++ b/packages/browser-vm/src/dynamicNode/index.ts
@@ -135,17 +135,6 @@ export function makeElInjector(sandboxConfig: SandboxOptions) {
   injectHandlerParams();
 }
 
-export function recordStyledComponentCSSRules(
-  dynamicStyleSheetElementSet: Set<HTMLStyleElement>,
-  styledComponentCSSRulesMap: WeakMap<HTMLStyleElement, CSSRuleList>,
-) {
-  dynamicStyleSheetElementSet.forEach((styleElement) => {
-    if (isStyledComponentsLike(styleElement) && styleElement.sheet) {
-      styledComponentCSSRulesMap.set(styleElement, styleElement.sheet.cssRules);
-    }
-  });
-}
-
 export function rebuildCSSRules(
   dynamicStyleSheetElementSet: Set<HTMLStyleElement>,
   styledComponentCSSRulesMap: WeakMap<HTMLStyleElement, CSSRuleList>,

--- a/packages/browser-vm/src/dynamicNode/processor.ts
+++ b/packages/browser-vm/src/dynamicNode/processor.ts
@@ -15,7 +15,7 @@ import {
   __REMOVE_NODE__,
 } from '@garfish/utils';
 import { Sandbox } from '../sandbox';
-import { rootElm, isStyledComponentsLike, LockQueue } from '../utils';
+import { rootElm, LockQueue } from '../utils';
 
 const isInsertMethod = makeMap(['insertBefore', 'insertAdjacentElement']);
 
@@ -249,26 +249,35 @@ export class DynamicNodeProcessor {
     };
 
     const mutator = new MutationObserver((mutations) => {
-      for (const { type, target, addedNodes } of mutations) {
+      for (const { type, addedNodes } of mutations) {
         if (type === 'childList') {
-          const el = target as HTMLStyleElement;
-          if (isStyledComponentsLike(el) && el.sheet) {
-            const originAddRule = el.sheet.insertRule;
-            el.sheet.insertRule = function () {
-              arguments[0] = modifyStyleCode(arguments[0]);
-              return originAddRule.apply(this, arguments);
-            };
-          } else {
-            if (addedNodes[0]?.textContent) {
-              addedNodes[0].textContent = modifyStyleCode(
-                addedNodes[0].textContent,
-              );
-            }
+          if (addedNodes[0]?.textContent) {
+            addedNodes[0].textContent = modifyStyleCode(
+              addedNodes[0].textContent,
+            );
           }
         }
       }
     });
     mutator.observe(this.el, { childList: true });
+
+    // Handle `sheet.insertRule` (styled-components)
+    Reflect.defineProperty(this.el, 'sheet', {
+      get: () => {
+        const sheet = Reflect.get(HTMLStyleElement.prototype, 'sheet', this.el);
+        if (sheet) {
+          const originAddRule = sheet.insertRule;
+          sheet.insertRule = function () {
+            arguments[0] = modifyStyleCode(arguments[0]);
+            return originAddRule.apply(this, arguments);
+          };
+          // Delete this getter after we hooked insertRule
+          Reflect.deleteProperty(this.el, 'sheet');
+        }
+        return sheet;
+      },
+      configurable: true,
+    });
   }
 
   private findParentNodeInApp(parentNode: Element, defaultInsert?: string) {
@@ -429,7 +438,6 @@ export class DynamicNodeProcessor {
         return this.nativeRemove.call(parentNode, this.el);
       }
     }
-
     return originProcess();
   }
 }

--- a/packages/browser-vm/src/pluginify.ts
+++ b/packages/browser-vm/src/pluginify.ts
@@ -2,7 +2,7 @@ import { interfaces } from '@garfish/core';
 import { warn, isPlainObject } from '@garfish/utils';
 import { Module } from './types';
 import { Sandbox } from './sandbox';
-import { recordStyledComponentCSSRules, rebuildCSSRules } from './dynamicNode';
+import { rebuildCSSRules } from './dynamicNode';
 
 declare module '@garfish/core' {
   export default interface Garfish {
@@ -141,15 +141,6 @@ function createOptions(Garfish: interfaces.Garfish) {
           },
         }),
       );
-    },
-
-    beforeUnmount(appInfo, appInstance) {
-      if (appInstance.vmSandbox) {
-        recordStyledComponentCSSRules(
-          appInstance.vmSandbox.dynamicStyleSheetElementSet,
-          appInstance.vmSandbox.styledComponentCSSRulesMap,
-        );
-      }
     },
 
     // If the app is uninstalled, the sandbox needs to clear all effects and then reset

--- a/packages/browser-vm/src/sandbox.ts
+++ b/packages/browser-vm/src/sandbox.ts
@@ -23,7 +23,12 @@ import { makeElInjector } from './dynamicNode';
 import { sandboxLifecycle } from './lifecycle';
 import { optimizeMethods, createFakeObject, sandboxMap } from './utils';
 import { __garfishGlobal__, GARFISH_OPTIMIZE_NAME } from './symbolTypes';
-import { Module, SandboxOptions, ReplaceGlobalVariables } from './types';
+import {
+  Module,
+  SandboxOptions,
+  ReplaceGlobalVariables,
+  StyledComponentCSSRulesData,
+} from './types';
 import {
   createHas,
   createGetter,
@@ -76,7 +81,7 @@ export class Sandbox {
   public dynamicStyleSheetElementSet = new Set<HTMLStyleElement>();
   public styledComponentCSSRulesMap = new WeakMap<
     HTMLStyleElement,
-    CSSRuleList
+    StyledComponentCSSRulesData
   >();
 
   private optimizeCode = ''; // To optimize the with statement

--- a/packages/browser-vm/src/types.ts
+++ b/packages/browser-vm/src/types.ts
@@ -36,3 +36,8 @@ export interface SandboxOptions {
   protectVariable?: () => Array<PropertyKey>;
   insulationVariable?: () => Array<PropertyKey>;
 }
+
+export interface StyledComponentCSSRulesData {
+  cssRuleList: CSSRuleList | undefined;
+  addingRules: string[];
+}

--- a/packages/browser-vm/src/types.ts
+++ b/packages/browser-vm/src/types.ts
@@ -37,7 +37,4 @@ export interface SandboxOptions {
   insulationVariable?: () => Array<PropertyKey>;
 }
 
-export interface StyledComponentCSSRulesData {
-  cssRuleList: CSSRuleList | undefined;
-  addingRules: string[];
-}
+export type StyledComponentCSSRulesData = Array<string>;

--- a/packages/browser-vm/src/utils.ts
+++ b/packages/browser-vm/src/utils.ts
@@ -166,8 +166,7 @@ export function isStyledComponentsLike(element: HTMLStyleElement) {
   // A styled-components liked element has no textContent but keep the rules in its sheet.cssRules.
   return (
     element instanceof HTMLStyleElement &&
-    !element.textContent &&
-    element.sheet?.cssRules.length
+    !element.textContent
   );
 }
 


### PR DESCRIPTION
## Description

Fixed:

- Some style rules inserted by `insertRule()` are not transformed by the `StyleManager` 
  (fixed by ~~overwriting `insertRule()` on the first time getting `style.sheet`~~ fake `sheet`)
- `cssRules` is empty after the app remount in case of the app was detached before "unmount"
  (fixed by changing the timing of saving cssRules)
- styled-components cannot `insertRule()` after the app remount because they keep the first `sheet` instance.
  (fixed by returning a fake `sheet` that always passthrough operations to the latest real `sheet`)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
