### PR TITLE
fix(loader): fix the requestConfig type definition in beforeLoad

### DIFF
--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -87,7 +87,7 @@ export class Loader {
     beforeLoad: new SyncWaterfallHook<{
       url: string;
       scope: string;
-      requestConfig: ResponseInit;
+      requestConfig: RequestInit;
     }>('beforeLoad'),
     fetch: new AsyncHook<[string, RequestInit], Response | void | false>(
       'fetch',

--- a/packages/loader/src/utils.ts
+++ b/packages/loader/src/utils.ts
@@ -38,5 +38,6 @@ export function copyResult(result) {
 export function mergeConfig(loader: Loader, url: string) {
   const extra = loader.requestConfig;
   const config = typeof extra === 'function' ? extra(url) : extra;
-  return { mode: 'cors', ...config } as RequestInit;
+  const mode: RequestMode = 'cors';
+  return { mode, ...config };
 }


### PR DESCRIPTION
## Description
fix(loader): fix the requestConfig type definition in beforeLoad

## Related Issue
![img_v2_fed0d4d5-683a-452a-8c67-60cdfa8d028g](https://github.com/web-infra-dev/garfish/assets/18045417/2b68a800-31cd-4a44-a034-506f5b76b4de)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
