### PR TITLE
fix: Avoid elements created through the create element ns api from escaping the sandbox

### DIFF
--- a/packages/browser-vm/src/dynamicNode/index.ts
+++ b/packages/browser-vm/src/dynamicNode/index.ts
@@ -114,7 +114,8 @@ export function makeElInjector(sandboxConfig: SandboxOptions) {
 
   if (typeof window.Element === 'function') {
     // iframe can read html container this can't point to proxyDocument has Illegal invocation error
-    if (sandboxConfig.fixBaseUrl) safeWrapper(() => handleOwnerDocument());
+    if (sandboxConfig.fixBaseUrl || sandboxConfig.fixOwnerDocument)
+      safeWrapper(() => handleOwnerDocument());
     const rewrite = (
       methods: Array<string>,
       builder: typeof injector | typeof injectorRemoveChild,

--- a/packages/browser-vm/src/pluginify.ts
+++ b/packages/browser-vm/src/pluginify.ts
@@ -130,11 +130,13 @@ function createOptions(Garfish: interfaces.Garfish) {
           fixStaticResourceBaseUrl: Boolean(
             appInfo.sandbox?.fixStaticResourceBaseUrl,
           ),
+          fixOwnerDocument: Boolean(appInfo.sandbox?.fixOwnerDocument),
           disableWith: Boolean(appInfo.sandbox?.disableWith),
           disableElementtiming: Boolean(appInfo.sandbox?.disableElementtiming),
           strictIsolation: Boolean(appInfo.sandbox?.strictIsolation),
           // 缓存模式，不收集副作用
-          disableCollect: appInfo.cache === undefined ? true : Boolean(appInfo.cache),
+          disableCollect:
+            appInfo.cache === undefined ? true : Boolean(appInfo.cache),
           el: () => appInstance.htmlNode,
           styleScopeId: () => appInstance.appContainer.id,
           protectVariable: () => appInfo.protectVariable || [],

--- a/packages/browser-vm/src/proxyInterceptor/document.ts
+++ b/packages/browser-vm/src/proxyInterceptor/document.ts
@@ -65,6 +65,12 @@ export function createGetter(sandbox: Sandbox) {
           const el = value.call(document, tagName, options);
           return setSandboxRef(el);
         };
+      }
+      if (p === 'createElementNS') {
+        return function (...args) {
+          const el = value.call(document, ...args);
+          return setSandboxRef(el);
+        };
       } else if (p === 'createTextNode') {
         return function (data) {
           const el = value.call(document, data);

--- a/packages/browser-vm/src/types.ts
+++ b/packages/browser-vm/src/types.ts
@@ -22,6 +22,7 @@ export interface SandboxOptions {
   namespace: string;
   baseUrl?: string;
   fixBaseUrl?: boolean;
+  fixOwnerDocument?: boolean;
   fixStaticResourceBaseUrl?: boolean;
   disableWith?: boolean;
   strictIsolation?: boolean;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -114,6 +114,7 @@ export const createDefaultOptions = () => {
       disableWith: false,
       strictIsolation: false,
       disableElementtiming: false,
+      fixOwnerDocument: false,
     },
     // global hooks
     beforeLoad: () => {},

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -81,6 +81,7 @@ export namespace interfaces {
     disableWith?: boolean;
     strictIsolation?: boolean;
     disableElementtiming?: boolean;
+    fixOwnerDocument?: boolean;
   }
 
   export interface Config {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,7 +153,7 @@ importers:
       '@types/jasmine': 3.10.6
       '@types/jasminewd2': 2.0.10
       '@types/node': 12.20.55
-      codelyzer: 6.0.2_tslint@6.1.3
+      codelyzer: 6.0.2_fguifr4nhga2d4u46kxhe5txsi
       html-webpack-plugin: 5.5.0_webpack@5.74.0
       jasmine-core: 3.6.0
       jasmine-spec-reporter: 5.0.2
@@ -537,10 +537,10 @@ importers:
       garfish: link:../../packages/garfish
       mobx-vue: 2.2.0_vue@2.6.13
       vue: 2.6.13
-      vue-router: 3.5.4
+      vue-router: 3.5.4_vue@2.6.13
       vuex: 3.6.2_vue@2.6.13
     devDependencies:
-      '@vue/cli-plugin-babel': 4.5.0_6y6nlhbz6vocxqxxh4gircq5qu
+      '@vue/cli-plugin-babel': 4.5.0_jzirqkl3cocjauksqbewkiku6a
       '@vue/cli-plugin-eslint': 4.5.0_6kom7lkru2mmpsgmmgrqr4tw2i
       '@vue/cli-service': 4.5.0_nixqlmt6zp7dzdzrxupl7pgsaa
       babel-eslint: 10.1.0_eslint@6.8.0
@@ -582,10 +582,10 @@ importers:
       garfish: link:../../packages/garfish
       mobx-vue: 2.2.0_vue@2.6.13
       vue: 2.6.13
-      vue-router: 3.5.4
+      vue-router: 3.5.4_vue@2.6.13
       vuex: 3.6.2_vue@2.6.13
     devDependencies:
-      '@vue/cli-plugin-babel': 4.5.19_i3xytcjajo3ybwwzaynirpoxde
+      '@vue/cli-plugin-babel': 4.5.19_hqz6i7bmlzupdvrxqdtclu4shm
       '@vue/cli-plugin-eslint': 4.5.19_fepo2kslcuyry2fkxxpiwlhxb4
       '@vue/cli-service': 4.5.19_nixqlmt6zp7dzdzrxupl7pgsaa
       babel-eslint: 10.1.0_eslint@6.8.0
@@ -625,7 +625,7 @@ importers:
       vue-router: 4.0.12_vue@3.2.31
       vuex: 3.6.2_vue@3.2.31
     devDependencies:
-      '@vue/cli-plugin-babel': 4.5.15_yhv5fqzhxgiw6gyui5xgu6y5ea
+      '@vue/cli-plugin-babel': 4.5.15_yecqdxnkw2wdliv6nfjhbfqysq
       '@vue/cli-plugin-eslint': 4.5.15_cwpzzkkjbctqoajr4lbsdvzfee
       '@vue/cli-service': 4.5.15_ee7biujstwg456ue5i7k23lvau
       '@vue/compiler-sfc': 3.2.31
@@ -1278,15 +1278,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.15.0 || >=16.10.0}
     dependencies:
       tslib: 2.3.1
-    dev: true
-
-  /@angular/compiler/9.0.0_tslib@1.14.1:
-    resolution: {integrity: sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==}
-    peerDependencies:
-      tslib: ^1.10.0
-    dependencies:
-      tslib: 1.14.1
-    dev: true
 
   /@angular/core/13.2.4_rxjs@6.6.7+zone.js@0.10.3:
     resolution: {integrity: sha512-cCgf8Crx86hvZQX8lc7Yy5fedRI4trAXYsysrJ7ISRohfFk31Z/W5BEpKO8CkX51Ja5IfJPyoI2DVVTvrwzsEQ==}
@@ -1298,19 +1289,6 @@ packages:
       rxjs: 6.6.7
       tslib: 2.3.1
       zone.js: 0.10.3
-    dev: false
-
-  /@angular/core/9.0.0_5vxzpnwefl6dwkmk3nf2qix3m4:
-    resolution: {integrity: sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==}
-    peerDependencies:
-      rxjs: ^6.5.3
-      tslib: ^1.10.0
-      zone.js: ~0.10.2
-    dependencies:
-      rxjs: 6.6.7
-      tslib: 1.14.1
-      zone.js: 0.10.3
-    dev: true
 
   /@angular/forms/13.2.4_pdupkt2lpvhltxexto2shiqqnq:
     resolution: {integrity: sha512-XdWJZy4zfJ4ZGEhKZBceHAAozBQZPp1BRl7m2j09EV2I6l/nLdrYhgKGd4UBUtJWyXElPEuEgLiKKdmlPKF5eQ==}
@@ -3674,6 +3652,13 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.9
 
+  /@babel/runtime/7.23.2:
+    resolution: {integrity: sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.0
+    dev: false
+
   /@babel/template/7.16.7:
     resolution: {integrity: sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==}
     engines: {node: '>=6.9.0'}
@@ -3795,7 +3780,6 @@ packages:
   /@discoveryjs/json-ext/0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
-    dev: true
 
   /@docsearch/css/3.2.0:
     resolution: {integrity: sha512-jnNrO2JVYYhj2pP2FomlHIy6220n6mrLn2t9v2/qc+rM7M/fbIcKMgk9ky4RN+L/maUEmteckzg6/PIYoAAXJg==}
@@ -4030,7 +4014,7 @@ packages:
       '@babel/preset-env': 7.18.10_@babel+core@7.18.10
       '@babel/preset-react': 7.18.6_@babel+core@7.18.10
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.10
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.23.2
       '@babel/runtime-corejs3': 7.18.9
       '@babel/traverse': 7.18.11
       '@docusaurus/cssnano-preset': 2.0.1
@@ -4087,7 +4071,7 @@ packages:
       serve-handler: 6.1.3
       shelljs: 0.8.5
       terser-webpack-plugin: 5.3.3_webpack@5.74.0
-      tslib: 2.4.0
+      tslib: 2.6.2
       update-notifier: 5.1.0
       url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
       wait-on: 6.0.1_debug@4.3.4
@@ -4130,7 +4114,7 @@ packages:
       cssnano-preset-advanced: 5.3.8_postcss@8.4.16
       postcss: 8.4.16
       postcss-sort-media-queries: 4.2.1_postcss@8.4.16
-      tslib: 2.4.0
+      tslib: 2.6.2
     dev: false
 
   /@docusaurus/logger/2.0.0-rc.1:
@@ -4146,7 +4130,7 @@ packages:
     engines: {node: '>=16.14'}
     dependencies:
       chalk: 4.1.2
-      tslib: 2.4.0
+      tslib: 2.6.2
     dev: false
 
   /@docusaurus/lqip-loader/2.0.0-rc.1_webpack@5.74.0:
@@ -4157,7 +4141,7 @@ packages:
       file-loader: 6.2.0_webpack@5.74.0
       lodash: 4.17.21
       sharp: 0.30.7
-      tslib: 2.4.0
+      tslib: 2.6.2
     transitivePeerDependencies:
       - webpack
     dev: false
@@ -4253,7 +4237,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       remark-emoji: 2.2.0
       stringify-object: 3.3.0
-      tslib: 2.4.0
+      tslib: 2.6.2
       unified: 9.2.2
       unist-util-visit: 2.0.3
       url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
@@ -4288,7 +4272,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       remark-emoji: 2.2.0
       stringify-object: 3.3.0
-      tslib: 2.4.0
+      tslib: 2.6.2
       unified: 9.2.2
       unist-util-visit: 2.0.3
       url-loader: 4.1.1_u4acmn7fe6yqgbrqzialkgh5lu
@@ -4410,7 +4394,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       reading-time: 1.5.0
-      tslib: 2.4.0
+      tslib: 2.6.2
       unist-util-visit: 2.0.3
       utility-types: 3.10.0
       webpack: 5.74.0
@@ -4560,7 +4544,7 @@ packages:
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      tslib: 2.4.0
+      tslib: 2.6.2
       webpack: 5.74.0
     transitivePeerDependencies:
       - '@parcel/css'
@@ -4998,7 +4982,7 @@ packages:
     engines: {node: '>=16.14'}
     dependencies:
       fs-extra: 10.1.0
-      tslib: 2.4.0
+      tslib: 2.6.2
     dev: false
 
   /@docusaurus/theme-translations/2.0.1:
@@ -5908,6 +5892,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
@@ -5917,6 +5902,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: false
     optional: true
@@ -5926,6 +5912,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
@@ -5935,6 +5922,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: false
     optional: true
@@ -6298,7 +6286,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@babel/types': 7.18.10
-      entities: 4.3.1
+      entities: 4.5.0
     dev: false
 
   /@svgr/plugin-jsx/6.3.1_@svgr+core@6.3.1:
@@ -6411,6 +6399,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -6420,6 +6409,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -6429,6 +6419,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -6438,6 +6429,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -7321,40 +7313,10 @@ packages:
       svg-tags: 1.0.0
     dev: true
 
-  /@vue/babel-preset-app/4.5.19_vue@2.6.13:
+  /@vue/babel-preset-app/4.5.19_core-js@3.21.1+vue@3.2.31:
     resolution: {integrity: sha512-VCNRiAt2P/bLo09rYt3DLe6xXUMlhJwrvU18Ddd/lYJgC7s8+wvhgYs+MTx4OiAXdu58drGwSBO9SPx7C6J82Q==}
     peerDependencies:
-      vue: ^2 || ^3.0.0-0
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-      vue:
-        optional: true
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-compilation-targets': 7.18.9_@babel+core@7.18.10
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-proposal-decorators': 7.18.10_@babel+core@7.18.10
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.10
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-runtime': 7.18.10_@babel+core@7.18.10
-      '@babel/preset-env': 7.18.10_@babel+core@7.18.10
-      '@babel/runtime': 7.18.9
-      '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.18.10
-      '@vue/babel-preset-jsx': 1.3.1_euwiqxoptllsj4yx5flofkjzdu
-      babel-plugin-dynamic-import-node: 2.3.3
-      core-js: 3.21.1
-      core-js-compat: 3.24.1
-      semver: 6.3.0
-      vue: 2.6.13
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@vue/babel-preset-app/4.5.19_vue@3.2.31:
-    resolution: {integrity: sha512-VCNRiAt2P/bLo09rYt3DLe6xXUMlhJwrvU18Ddd/lYJgC7s8+wvhgYs+MTx4OiAXdu58drGwSBO9SPx7C6J82Q==}
-    peerDependencies:
+      core-js: ^3
       vue: ^2 || ^3.0.0-0
     peerDependenciesMeta:
       core-js:
@@ -7379,6 +7341,38 @@ packages:
       core-js-compat: 3.24.1
       semver: 6.3.0
       vue: 3.2.31
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vue/babel-preset-app/4.5.19_core-js@3.24.1+vue@2.6.13:
+    resolution: {integrity: sha512-VCNRiAt2P/bLo09rYt3DLe6xXUMlhJwrvU18Ddd/lYJgC7s8+wvhgYs+MTx4OiAXdu58drGwSBO9SPx7C6J82Q==}
+    peerDependencies:
+      core-js: ^3
+      vue: ^2 || ^3.0.0-0
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+      vue:
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.10
+      '@babel/helper-compilation-targets': 7.18.9_@babel+core@7.18.10
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.18.10
+      '@babel/plugin-proposal-decorators': 7.18.10_@babel+core@7.18.10
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.10
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.10
+      '@babel/plugin-transform-runtime': 7.18.10_@babel+core@7.18.10
+      '@babel/preset-env': 7.18.10_@babel+core@7.18.10
+      '@babel/runtime': 7.18.9
+      '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.18.10
+      '@vue/babel-preset-jsx': 1.3.1_euwiqxoptllsj4yx5flofkjzdu
+      babel-plugin-dynamic-import-node: 2.3.3
+      core-js: 3.24.1
+      core-js-compat: 3.24.1
+      semver: 6.3.0
+      vue: 2.6.13
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7490,13 +7484,13 @@ packages:
     resolution: {integrity: sha512-GdxvNSmOw7NHIazCO8gTK+xZbaOmScTtxj6eHVeMbYpDYVPJ+th3VMLWNpw/b6uOjwzzcyKlA5dRQ1DAb+gF/g==}
     dev: true
 
-  /@vue/cli-plugin-babel/4.5.0_6y6nlhbz6vocxqxxh4gircq5qu:
+  /@vue/cli-plugin-babel/4.5.0_jzirqkl3cocjauksqbewkiku6a:
     resolution: {integrity: sha512-o2FmvSPyeZ1hP7tnwP3qCoWyNzSd3Mi99yu7Ml/DNaJiz86eF6cL8GcTEgnYvtaq+jiMaCl+Ut69WXLoP5Qd6w==}
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     dependencies:
       '@babel/core': 7.18.10
-      '@vue/babel-preset-app': 4.5.19_vue@2.6.13
+      '@vue/babel-preset-app': 4.5.19_core-js@3.24.1+vue@2.6.13
       '@vue/cli-service': 4.5.0_nixqlmt6zp7dzdzrxupl7pgsaa
       '@vue/cli-shared-utils': 4.5.19
       babel-loader: 8.2.5_5ouqwanl7jnotevpn4w6qovjqm
@@ -7504,19 +7498,20 @@ packages:
       thread-loader: 2.1.3_webpack@4.46.0
       webpack: 4.46.0
     transitivePeerDependencies:
+      - core-js
       - supports-color
       - vue
       - webpack-cli
       - webpack-command
     dev: true
 
-  /@vue/cli-plugin-babel/4.5.15_yhv5fqzhxgiw6gyui5xgu6y5ea:
+  /@vue/cli-plugin-babel/4.5.15_yecqdxnkw2wdliv6nfjhbfqysq:
     resolution: {integrity: sha512-hBLrwYfFkHldEe34op/YNgPhpOWI5n5DB2Qt9I/1Epeif4M4iFaayrgjvOR9AVM6WbD3Yx7WCFszYpWrQZpBzQ==}
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     dependencies:
       '@babel/core': 7.18.10
-      '@vue/babel-preset-app': 4.5.19_vue@3.2.31
+      '@vue/babel-preset-app': 4.5.19_core-js@3.21.1+vue@3.2.31
       '@vue/cli-service': 4.5.15_ee7biujstwg456ue5i7k23lvau
       '@vue/cli-shared-utils': 4.5.19
       babel-loader: 8.2.5_5ouqwanl7jnotevpn4w6qovjqm
@@ -7524,19 +7519,20 @@ packages:
       thread-loader: 2.1.3_webpack@4.46.0
       webpack: 4.46.0
     transitivePeerDependencies:
+      - core-js
       - supports-color
       - vue
       - webpack-cli
       - webpack-command
     dev: true
 
-  /@vue/cli-plugin-babel/4.5.19_i3xytcjajo3ybwwzaynirpoxde:
+  /@vue/cli-plugin-babel/4.5.19_hqz6i7bmlzupdvrxqdtclu4shm:
     resolution: {integrity: sha512-8ebXzaMW9KNTMAN6+DzkhFsjty1ieqT7hIW5Lbk4v30Qhfjkms7lBWyXPGkoq+wAikXFa1Gnam2xmWOBqDDvWg==}
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     dependencies:
       '@babel/core': 7.18.10
-      '@vue/babel-preset-app': 4.5.19_vue@2.6.13
+      '@vue/babel-preset-app': 4.5.19_core-js@3.24.1+vue@2.6.13
       '@vue/cli-service': 4.5.19_nixqlmt6zp7dzdzrxupl7pgsaa
       '@vue/cli-shared-utils': 4.5.19
       babel-loader: 8.2.5_5ouqwanl7jnotevpn4w6qovjqm
@@ -7544,6 +7540,7 @@ packages:
       thread-loader: 2.1.3_webpack@4.46.0
       webpack: 4.46.0
     transitivePeerDependencies:
+      - core-js
       - supports-color
       - vue
       - webpack-cli
@@ -8174,7 +8171,7 @@ packages:
       source-map: 0.6.1
       vue-template-es2015-compiler: 1.9.1
     optionalDependencies:
-      prettier: 2.7.1
+      prettier: 2.4.1
     transitivePeerDependencies:
       - arc-templates
       - atpl
@@ -8515,7 +8512,6 @@ packages:
     dependencies:
       webpack: 5.74.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_foudhxygz4mdqapuaanowzkgwm
-    dev: true
 
   /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
@@ -8524,7 +8520,6 @@ packages:
     dependencies:
       envinfo: 7.8.1
       webpack-cli: 4.10.0_foudhxygz4mdqapuaanowzkgwm
-    dev: true
 
   /@webpack-cli/serve/1.7.0_jrmoy2z4ppm6sherzyq2k2csya:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -8537,7 +8532,6 @@ packages:
     dependencies:
       webpack-cli: 4.10.0_foudhxygz4mdqapuaanowzkgwm
       webpack-dev-server: 4.9.3_5v66e2inugklgvlh4huuavolfq
-    dev: true
 
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -8644,7 +8638,6 @@ packages:
     resolution: {integrity: sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: false
 
   /acorn/8.8.0:
     resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
@@ -8691,7 +8684,7 @@ packages:
     resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       depd: 1.1.2
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -10716,13 +10709,15 @@ packages:
       - supports-color
     dev: true
 
-  /codelyzer/6.0.2_tslint@6.1.3:
+  /codelyzer/6.0.2_fguifr4nhga2d4u46kxhe5txsi:
     resolution: {integrity: sha512-v3+E0Ucu2xWJMOJ2fA/q9pDT/hlxHftHGPUay1/1cTgyPV5JTHFdO9hqo837Sx2s9vKBMTt5gO+lhF95PO6J+g==}
     peerDependencies:
+      '@angular/compiler': '>=2.3.1 <13.0.0 || ^12.0.0-next || ^12.1.0-next || ^12.2.0-next'
+      '@angular/core': '>=2.3.1 <13.0.0 || ^12.0.0-next || ^12.1.0-next || ^12.2.0-next'
       tslint: ^5.0.0 || ^6.0.0
     dependencies:
-      '@angular/compiler': 9.0.0_tslib@1.14.1
-      '@angular/core': 9.0.0_5vxzpnwefl6dwkmk3nf2qix3m4
+      '@angular/compiler': 13.3.11
+      '@angular/core': 13.2.4_rxjs@6.6.7+zone.js@0.10.3
       app-root-path: 3.0.0
       aria-query: 3.0.0
       axobject-query: 2.0.2
@@ -12524,7 +12519,7 @@ packages:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
-      entities: 4.3.1
+      entities: 4.5.0
     dev: false
 
   /dom7/4.0.4:
@@ -12821,8 +12816,8 @@ packages:
   /entities/2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
-  /entities/4.3.1:
-    resolution: {integrity: sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==}
+  /entities/4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
     dev: false
 
@@ -12835,7 +12830,6 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /err-code/2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -13905,7 +13899,6 @@ packages:
   /fastest-levenshtein/1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
-    dev: true
 
   /fastparse/1.1.2:
     resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
@@ -14218,7 +14211,7 @@ packages:
     resolution: {integrity: sha512-pZ2bO++NWLHhiKkgP1bEXHhR1/OjVcSvlCJ98aNJDFeb7H5OOQaO+SKOZle6041O9rv2tmbrO4JzClAvDUHf0g==}
     engines: {node: '>=10'}
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.3.1
     dev: false
 
   /follow-redirects/1.15.1:
@@ -14420,7 +14413,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
@@ -15438,7 +15431,7 @@ packages:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       domutils: 3.0.1
-      entities: 4.3.1
+      entities: 4.5.0
     dev: false
 
   /http-cache-semantics/4.1.0:
@@ -15486,7 +15479,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15860,7 +15853,6 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
-    dev: true
 
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -16005,7 +15997,6 @@ packages:
   /interpret/2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
-    dev: true
 
   /invariant/2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -17211,7 +17202,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.8.0
+      acorn: 8.7.0
       acorn-globals: 6.0.0
       cssom: 0.4.4
       cssstyle: 2.3.0
@@ -18038,7 +18029,7 @@ packages:
     resolution: {integrity: sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==}
     hasBin: true
     optionalDependencies:
-      minimist: 1.2.6
+      minimist: 1.2.5
     dev: true
 
   /makeerror/1.0.12:
@@ -18671,7 +18662,7 @@ packages:
       prop-types: ^15.0.0
       react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.19.0
       prop-types: 15.8.1
       react: 17.0.2
       tiny-warning: 1.0.3
@@ -18745,6 +18736,7 @@ packages:
 
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+    dev: true
 
   /minipass-collect/1.0.2:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
@@ -18943,7 +18935,7 @@ packages:
       kleur: 3.0.3
       listify: 1.0.3
       lodash: 4.17.21
-      minimist: 1.2.6
+      minimist: 1.2.5
       prop-ini: 0.0.2
       rc: 1.2.8
       readme-badger: 0.3.0
@@ -18971,7 +18963,7 @@ packages:
       lodash: 4.17.21
       longest: 2.0.1
       middleearth-names: 1.1.0
-      minimist: 1.2.6
+      minimist: 1.2.5
       mrm-core: 6.1.7
       semver-utils: 1.1.4
       update-notifier: 4.1.3
@@ -19049,6 +19041,12 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  /nanoid/3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
 
   /nanomatch/1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -19972,7 +19970,7 @@ packages:
   /parse5/7.0.0:
     resolution: {integrity: sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==}
     dependencies:
-      entities: 4.3.1
+      entities: 4.5.0
     dev: false
 
   /parseqs/0.0.6:
@@ -21314,7 +21312,7 @@ packages:
     resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.4
+      nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: true
@@ -21327,7 +21325,7 @@ packages:
       detect-libc: 2.0.1
       expand-template: 2.0.3
       github-from-package: 0.0.0
-      minimist: 1.2.6
+      minimist: 1.2.5
       mkdirp-classic: 0.5.3
       napi-build-utils: 1.0.2
       node-abi: 3.24.0
@@ -21414,14 +21412,6 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
-
-  /prettier/2.7.1:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /pretty-bytes/5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
@@ -21792,7 +21782,7 @@ packages:
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
-      minimist: 1.2.6
+      minimist: 1.2.5
       strip-json-comments: 2.0.1
 
   /react-base16-styling/0.6.0:
@@ -21809,7 +21799,7 @@ packages:
     peerDependencies:
       react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.19.0
+      '@babel/runtime': 7.18.9
       react: 16.14.0
     dev: false
 
@@ -21834,6 +21824,12 @@ packages:
   /react-dev-utils/12.0.1_webpack@5.74.0:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=2.7'
+      webpack: '>=4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       address: 1.2.0
@@ -21859,12 +21855,11 @@ packages:
       shell-quote: 1.7.3
       strip-ansi: 6.0.1
       text-table: 0.2.0
+      webpack: 5.74.0
     transitivePeerDependencies:
       - eslint
       - supports-color
-      - typescript
       - vue-template-compiler
-      - webpack
     dev: false
 
   /react-dom/16.14.0_react@16.14.0:
@@ -21877,7 +21872,6 @@ packages:
       prop-types: 15.8.1
       react: 16.14.0
       scheduler: 0.19.1
-    dev: false
 
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -22239,7 +22233,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.23.2
       react: 17.0.2
       use-composed-ref: 1.3.0_react@17.0.2
       use-latest: 1.2.1_skqlhrap4das3cz5b6iqdn2lqi
@@ -22294,7 +22288,7 @@ packages:
     peerDependencies:
       react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@babel/runtime': 7.23.2
       consolidated-events: 2.0.2
       prop-types: 15.8.1
       react: 17.0.2
@@ -22308,7 +22302,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.8.1
-    dev: false
 
   /react/17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -22425,7 +22418,6 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       resolve: 1.22.1
-    dev: true
 
   /recursive-readdir/2.2.2:
     resolution: {integrity: sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==}
@@ -22487,6 +22479,10 @@ packages:
 
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
+
+  /regenerator-runtime/0.14.0:
+    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
+    dev: false
 
   /regenerator-transform/0.15.0:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
@@ -22942,7 +22938,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
-    dev: true
 
   /resolve-from/3.0.0:
     resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==}
@@ -22956,7 +22951,6 @@ packages:
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-    dev: true
 
   /resolve-pathname/3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
@@ -23169,7 +23163,6 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       semver: 7.3.7
-    dev: false
 
   /sass-loader/12.4.0_sass@1.49.9+webpack@5.70.0:
     resolution: {integrity: sha512-7xN+8khDIzym1oL9XyS6zP6Ges+Bo2B2xbPrjdMHEYyV3AQYhd/wXeru++3ODHF0zMjYmVadblSKrPrjEkL8mg==}
@@ -23226,7 +23219,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: false
 
   /scheduler/0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
@@ -23838,7 +23830,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.3
+      debug: 4.3.4
       socks: 2.7.0
     transitivePeerDependencies:
       - supports-color
@@ -23849,7 +23841,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.3
+      debug: 4.3.4
       socks: 2.7.0
     transitivePeerDependencies:
       - supports-color
@@ -25108,6 +25100,10 @@ packages:
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
+  /tslib/2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    dev: false
+
   /tslint/6.1.3_typescript@4.4.3:
     resolution: {integrity: sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==}
     engines: {node: '>=4.8.0'}
@@ -25366,6 +25362,7 @@ packages:
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -25377,6 +25374,7 @@ packages:
   /unified/9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -25754,7 +25752,7 @@ packages:
         optional: true
     dependencies:
       react: 16.14.0
-      tslib: 2.4.0
+      tslib: 2.3.1
     dev: false
 
   /use-callback-ref/1.3.0_react@17.0.2:
@@ -25768,7 +25766,7 @@ packages:
         optional: true
     dependencies:
       react: 17.0.2
-      tslib: 2.4.0
+      tslib: 2.3.1
     dev: false
 
   /use-callback-ref/1.3.0_react@18.1.0:
@@ -25782,7 +25780,7 @@ packages:
         optional: true
     dependencies:
       react: 18.1.0
-      tslib: 2.4.0
+      tslib: 2.3.1
     dev: false
 
   /use-composed-ref/1.3.0_react@17.0.2:
@@ -25832,7 +25830,7 @@ packages:
     dependencies:
       detect-node-es: 1.1.0
       react: 16.14.0
-      tslib: 2.4.0
+      tslib: 2.3.1
     dev: false
 
   /use-sidecar/1.1.2_react@17.0.2:
@@ -25847,7 +25845,7 @@ packages:
     dependencies:
       detect-node-es: 1.1.0
       react: 17.0.2
-      tslib: 2.4.0
+      tslib: 2.3.1
     dev: false
 
   /use-sidecar/1.1.2_react@18.1.0:
@@ -25862,7 +25860,7 @@ packages:
     dependencies:
       detect-node-es: 1.1.0
       react: 18.1.0
-      tslib: 2.4.0
+      tslib: 2.3.1
     dev: false
 
   /use/3.1.1:
@@ -26410,8 +26408,12 @@ packages:
       webpack: 4.46.0
     dev: true
 
-  /vue-router/3.5.4:
+  /vue-router/3.5.4_vue@2.6.13:
     resolution: {integrity: sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ==}
+    peerDependencies:
+      vue: ^2
+    dependencies:
+      vue: 2.6.13
     dev: false
 
   /vue-router/4.0.12_vue@3.2.31:
@@ -26474,6 +26476,7 @@ packages:
 
   /w3c-hr-time/1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
+    deprecated: Use your platform's native performance.now() and performance.timeOrigin.
     dependencies:
       browser-process-hrtime: 1.0.0
     dev: true
@@ -26693,7 +26696,6 @@ packages:
       webpack: 5.74.0_webpack-cli@4.10.0
       webpack-dev-server: 4.9.3_5v66e2inugklgvlh4huuavolfq
       webpack-merge: 5.8.0
-    dev: true
 
   /webpack-dev-middleware/3.7.3_webpack@4.46.0:
     resolution: {integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==}
@@ -26882,7 +26884,6 @@ packages:
       - debug
       - supports-color
       - utf-8-validate
-    dev: true
 
   /webpack-dev-server/4.9.3_debug@4.3.4+webpack@5.74.0:
     resolution: {integrity: sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==}
@@ -27185,7 +27186,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /webpackbar/5.0.2_webpack@5.74.0:
     resolution: {integrity: sha512-BmFJo7veBDgQzfWXl/wwYXr/VFus0614qZ8i9znqcl9fnEdiVkdbi0TedLQ6xAK92HZHDJ0QmyQ0fmuZPAgCYQ==}
@@ -27698,7 +27698,7 @@ packages:
     resolution: {directory: packages/bridge-react, type: directory}
     id: file:packages/bridge-react
     name: '@garfish/bridge-react'
-    version: 1.11.1
+    version: 1.17.1
     peerDependencies:
       react: '>=16'
       react-dom: '>=16'
@@ -27712,7 +27712,7 @@ packages:
     resolution: {directory: packages/bridge-react, type: directory}
     id: file:packages/bridge-react
     name: '@garfish/bridge-react'
-    version: 1.11.1
+    version: 1.17.1
     peerDependencies:
       react: '>=16'
       react-dom: '>=16'

--- a/website/src/components/config/_sandbox.mdx
+++ b/website/src/components/config/_sandbox.mdx
@@ -18,6 +18,8 @@ interface SandboxConfig {
   modules?: Array<Module> | Record<string, Module>;
   // disableElementtiming 1.14.4 版本提供，默认值为 false，将会给子应用元素注入 elementtiming 属性，可以通过此属性获取子应用元素的加载时间
   disableElementtiming?: boolean;
+  // fixOwnerDocument  1.17.2 版本提供 ，默认值 false，目前可能会存在 ownerDocument 逃逸的情况，设置为 true 之后将会避免 ownerDocument 逃逸
+  fixOwnerDocument?: boolean;
 }
 
 type Module = (sandbox: Sandbox) => OverridesData | void;


### PR DESCRIPTION
## Description

* Avoid escaping the sandbox when an element created through the create Element ns api gets the owner document
* Added the owner document configuration

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
