### PR TITLE
fix: TemplateManager.findAttributeValue对值为空的HTML布尔属性处理错误

### DIFF
--- a/packages/core/src/module/app.ts
+++ b/packages/core/src/module/app.ts
@@ -714,10 +714,9 @@ export class App {
               async: false,
               defer: false,
               isInline: jsManager.isInlineScript(),
-              noEntry: toBoolean(
-                entryManager.findAttributeValue(node, 'no-entry') ||
-                  this.isNoEntryScript(targetUrl),
-              ),
+              noEntry:
+                toBoolean(entryManager.findAttributeValue(node, 'no-entry')) ||
+                toBoolean(this.isNoEntryScript(targetUrl)),
               originScript: mockOriginScript,
             });
           }

--- a/packages/core/src/module/resource.ts
+++ b/packages/core/src/module/resource.ts
@@ -22,10 +22,13 @@ function fetchStaticResources(
       .map((node) => {
         const src = entryManager.findAttributeValue(node, 'src');
         const type = entryManager.findAttributeValue(node, 'type');
-        const crossOrigin = entryManager.findAttributeValue(
+        let crossOrigin = entryManager.findAttributeValue(
           node,
           'crossorigin',
         );
+        if (crossOrigin === '') {
+          crossOrigin = 'anonymous';
+        }
 
         // There should be no embedded script in the script element tag with the src attribute specified
         if (src) {

--- a/packages/loader/src/managers/template.ts
+++ b/packages/loader/src/managers/template.ts
@@ -144,7 +144,7 @@ export class TemplateManager {
   }
 
   findAttributeValue(node: Node, type: string) {
-    return node.attributes?.find(({ key }) => key === type)?.value || undefined;
+    return node.attributes?.find(({ key }) => key === type)?.value ?? undefined;
   }
 
   cloneNode(node: Node) {


### PR DESCRIPTION
## Description
修复的问题参考[此issue](https://github.com/web-infra-dev/garfish/issues/659)
改动点：
- 将findAttributeValue中的`||`修改为`??`
- 对逻辑受影响的地方进行调整（包含两处：packages/core/src/module/resource.ts中的crossorigin，以及packages/core/src/module/app.ts中的no-entry。其他使用findAttributeValue的地方目测不受影响）


<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue
[https://github.com/web-infra-dev/garfish/issues/659](https://github.com/web-infra-dev/garfish/issues/659)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
