### PR TITLE
docs: update architecture blog url

### DIFF
--- a/website-new/docs/guide/quick-start/index.md
+++ b/website-new/docs/guide/quick-start/index.md
@@ -43,7 +43,7 @@ Garfish 是一套 [微前端](https://micro-frontends.org/) 解决方案，主�
 
 ![image.png](https://p-vcloud.byteimg.com/tos-cn-i-em5hxbkur4/d456c7d2235c41daa298aba69ade435f~tplv-em5hxbkur4-noop.image?width=1126&height=454)
 
-具体可参考 [微前端架构设计](/blog) 这篇文章中的详细介绍
+具体可参考 [微前端架构设计](/blog/architecture) 这篇文章中的详细介绍
 
 ## 什么时候用
 


### PR DESCRIPTION
## Description

The link jump is abnormal.

Clicking on the link of micro front-end architecture design jumps to the 404 page.
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/5009c946-7790-4b78-9f98-e6e4085b4890" />
<img width="1223" alt="image" src="https://github.com/user-attachments/assets/59247d65-2cbe-43c4-ae91-9792e816f92f" />


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
