### PR TITLE
fix(browser-vm): vm network fakefetch to be compatible with the axios fetch adapter

### DIFF
--- a/packages/browser-vm/src/modules/network.ts
+++ b/packages/browser-vm/src/modules/network.ts
@@ -26,7 +26,7 @@ export function networkModule(sandbox: Sandbox) {
     }
 
     open() {
-      // sync request 
+      // sync request
       if (arguments[2] === false) {
         xhrSet.delete(this);
       }
@@ -83,7 +83,7 @@ export function networkModule(sandbox: Sandbox) {
       });
     }
     let controller;
-    if (!hasOwn(options, 'signal') && window.AbortController) {
+    if (!(input instanceof Request) && !hasOwn(options, 'signal') && window.AbortController) {
       controller = new window.AbortController();
       if (!sandbox.options.disableCollect) {
         fetchSet.add(controller);


### PR DESCRIPTION
Fix compatibility issue with fakefetch when using Axios fetch adapter.

## Description

修复browser-vm模块fakefetch中判断不存在signal时自动添加逻辑与axios的fetch adapter冲突的问题。
axios中fetch adapter会向fetch传入Request实例，导致fakefetch 判断signal是否存在的逻辑失效。

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
