### PR TITLE
fix: retain currentScript reference when processing async/defer script

### DIFF
--- a/dev/app-react-18/public/index.html
+++ b/dev/app-react-18/public/index.html
@@ -2,7 +2,12 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>app react v17</title>
+    <title>app react v18</title>
+    <script
+      src="./scripts/readCurrentScript.js"
+      data-appkey="supply"
+      async="true"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/dev/app-react-18/public/scripts/readCurrentScript.js
+++ b/dev/app-react-18/public/scripts/readCurrentScript.js
@@ -1,0 +1,5 @@
+const currentScript = document.currentScript;
+if (!currentScript.dataset.testName) {
+  throw new Error('currentScript.dataset.testName is required')
+}
+


### PR DESCRIPTION


## Description
retain currentScript reference when processing async/defer scripts to prevent data-* attribute read failures

dev/app-react-18/public/index.html

```html
<script
      src="./scripts/readCurrentScript.js"
      data-appkey="supply"
      async="true"
    ></script>
```

the currentScript property will not be read


<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
