### PR TITLE
fix: optimize sandbox deferClearEffects memory leak

### DIFF
--- a/packages/browser-vm/src/dynamicNode/processor.ts
+++ b/packages/browser-vm/src/dynamicNode/processor.ts
@@ -389,10 +389,11 @@ export class DynamicNodeProcessor {
       document.contains(parentNode)
     ) {
       if (parentNode !== this.rootElement) {
-        this.sandbox.deferClearEffects.add(() => {
+        const clearCallback = new WeakRef(() => {
           this.DOMApis.removeElement(this.el);
           return this.el;
         });
+        this.sandbox.deferClearEffects.add(clearCallback);
       }
     }
 

--- a/packages/browser-vm/src/index.ts
+++ b/packages/browser-vm/src/index.ts
@@ -1,3 +1,4 @@
+import './polyfill/weakRef';
 export { GarfishBrowserVm } from './pluginify';
 export { Sandbox as default } from './sandbox';
 export type {

--- a/packages/browser-vm/src/polyfill/weakRef.ts
+++ b/packages/browser-vm/src/polyfill/weakRef.ts
@@ -1,0 +1,65 @@
+// ref: https://github.com/jaenster/weakref-pollyfill/blob/master/src/index.js
+(function (global) {
+  if (
+    typeof global === 'object' &&
+    global &&
+    typeof global['WeakRef'] === 'undefined'
+  ) {
+    global.WeakRef = (function (wm) {
+      function WeakRef(this: any, target) {
+        wm.set(this, target);
+      }
+
+      WeakRef.prototype.deref = function () {
+        return wm.get(this);
+      };
+
+      return WeakRef;
+    })(new WeakMap());
+  }
+})(
+  (function () {
+    switch (true) {
+      case typeof globalThis === 'object' && !!globalThis:
+        return globalThis;
+      case typeof self === 'object' && !!self:
+        return self;
+      case typeof window === 'object' && !!window:
+        return window;
+      case typeof Function === 'function':
+        return Function('return this')();
+    }
+    return null;
+  })(),
+);
+
+declare global {
+  type IWeakKey = object;
+
+  // ref: https://github.com/microsoft/TypeScript/blob/main/src/lib/es2021.weakref.d.ts
+  interface WeakRef<T extends IWeakKey> {
+    readonly [Symbol.toStringTag]: 'WeakRef';
+
+    /**
+     * Returns the WeakRef instance's target value, or undefined if the target value has been
+     * reclaimed.
+     * In es2023 the value can be either a symbol or an object, in previous versions only object is permissible.
+     */
+    deref(): T | undefined;
+  }
+
+  interface WeakRefConstructor {
+    readonly prototype: WeakRef<any>;
+
+    /**
+     * Creates a WeakRef instance for the given target value.
+     * In es2023 the value can be either a symbol or an object, in previous versions only object is permissible.
+     * @param target The target value for the WeakRef instance.
+     */
+    new <T extends IWeakKey>(target: T): WeakRef<T>;
+  }
+
+  export let WeakRef: WeakRefConstructor;
+}
+
+export {};

--- a/packages/browser-vm/src/sandbox.ts
+++ b/packages/browser-vm/src/sandbox.ts
@@ -74,7 +74,7 @@ export class Sandbox {
   public options: SandboxOptions;
   public hooks = sandboxLifecycle();
   public replaceGlobalVariables: ReplaceGlobalVariables;
-  public deferClearEffects: Set<() => void> = new Set();
+  public deferClearEffects: Set<WeakRef<() => void>> = new Set();
   public isExternalGlobalVariable: Set<PropertyKey> = new Set();
   public isProtectVariable: (p: PropertyKey) => boolean;
   public isInsulationVariable: (P: PropertyKey) => boolean;
@@ -243,7 +243,7 @@ export class Sandbox {
     this.hooks.lifecycle.beforeClearEffect.emit();
     this.replaceGlobalVariables.recoverList.forEach((fn) => fn && fn());
     // `deferClearEffects` needs to be put at the end
-    this.deferClearEffects.forEach((fn) => fn && fn());
+    this.deferClearEffects.forEach((fn) => fn && fn.deref()?.());
     this.hooks.lifecycle.afterClearEffect.emit();
   }
 


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->

优化sandbox.deferClearEffects的内存泄露

<!--- Describe your changes in detail -->


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#720 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [ ] I have updated the documentation.
