### PR TITLE
fix: ts typings reference

### DIFF
--- a/packages/bridge-react-v18/package.json
+++ b/packages/bridge-react-v18/package.json
@@ -21,9 +21,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/bridge-react/package.json
+++ b/packages/bridge-react/package.json
@@ -21,9 +21,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/bridge-vue-v2/package.json
+++ b/packages/bridge-vue-v2/package.json
@@ -22,9 +22,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/bridge-vue-v3/package.json
+++ b/packages/bridge-vue-v3/package.json
@@ -22,9 +22,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/browser-snapshot/package.json
+++ b/packages/browser-snapshot/package.json
@@ -18,9 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/browser-vm/package.json
+++ b/packages/browser-vm/package.json
@@ -18,9 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,9 +19,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/css-scope/package.json
+++ b/packages/css-scope/package.json
@@ -18,9 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/es-module/package.json
+++ b/packages/es-module/package.json
@@ -18,9 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/garfish/index.d.ts
+++ b/packages/garfish/index.d.ts
@@ -1,6 +1,6 @@
-/// <reference types="@garfish/browser-vm/dist" />
-/// <reference types="@garfish/browser-snapshot/dist" />
-/// <reference types="@garfish/router/dist" />
+/// <reference types="@garfish/browser-vm" />
+/// <reference types="@garfish/browser-snapshot" />
+/// <reference types="@garfish/router" />
 export * from './dist/index';
 import defaultInstance from './dist/index';
 

--- a/packages/garfish/package.json
+++ b/packages/garfish/package.json
@@ -18,9 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -11,9 +11,9 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -18,9 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/remote-module/package.json
+++ b/packages/remote-module/package.json
@@ -18,9 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -18,9 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -18,9 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,9 +18,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
## Description

previous typings references only work when `moduleResolution` is set to `node` or `node10`, and they break in `node16`, `nodenext`, or `bundler`.

> [The "types" condition should always come first in "exports". | TypeScript: Documentation - TypeScript 4.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#:~:text=The%20%22types%22%20condition%20should%20always%20come%20first%20in%20%22exports%22.)

## Related Issue

close #717

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
