### PR TITLE
fix: fix the error of passing parameters when binding function to window

### DIFF
--- a/packages/browser-vm/__tests__/sandbox.spec.ts
+++ b/packages/browser-vm/__tests__/sandbox.spec.ts
@@ -230,4 +230,16 @@ describe('Sandbox', () => {
     );
     env.a = 'changedEnvA';
   });
+
+  it('func in window bound test', (next) => {
+    const NOOP = () => {};
+    NOOP.n = 111;
+    (window as any).n = NOOP;
+    expect((window as any).n).toBe(NOOP);
+    expect((window as any).n.n).toBe(111);
+    sandbox.execScript(
+      go('expect(window.n.n).toBe(111);next();'),
+      { next }
+    );
+  });
 });

--- a/packages/browser-vm/src/proxyInterceptor/shared.ts
+++ b/packages/browser-vm/src/proxyInterceptor/shared.ts
@@ -114,12 +114,12 @@ const buildInProps = makeMap([
   Symbol.hasInstance,
 ]);
 
-function transferProps(o: Function, n: Function) {
-  for (const key of Reflect.ownKeys(o)) {
+function transferProps(source: Function, target: Function) {
+  for (const key of Reflect.ownKeys(source)) {
     if (buildInProps(key)) continue;
-    const desc = Object.getOwnPropertyDescriptor(n, key);
+    const desc = Object.getOwnPropertyDescriptor(source, key);
     if (desc && desc.writable) {
-      n[key] = o[key];
+      target[key] = source[key];
     }
   }
 }


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

```ts
(window as any).a = function () {
    return 11;
};

(window as any).a.aa = 1;

const vm = new VM({
    namespace: '111',
});

vm.start();
// get 11
vm.execScript(`console.log(window.a());`);
// get undefined, but expect `1`
vm.execScript(`console.log(window.a.aa);`);
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
